### PR TITLE
Add overload meltdown and heat cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ not require a web server.  You should see:
 * **Delete** – removes the component from the selected grid cell.
 
 **Start** the simulation and watch heat and power accumulate.  **Sell Power**
-converts all stored power into money.  When heat exceeds the reactor’s
-capacity, a melt‑down occurs and all fuel cells are removed.
+converts all stored power into money.  Heat and power are capped at their
+respective capacities.  When heat reaches capacity, a melt‑down occurs and all
+fuel cells are removed.  If power reaches capacity, the reactor overloads and
+all components are destroyed.
 
 This prototype implements only a small subset of the planned features.  It
 serves as a foundation for further development with Codex, such as adding

--- a/components.js
+++ b/components.js
@@ -206,8 +206,8 @@ export class ReactorState {
    * @param {number} amount
    */
   addHeat(amount) {
-    this.heat += amount;
-    // Overflow remains as heat; melt‑down checks occur in game loop
+    // Increase heat but do not exceed capacity
+    this.heat = Math.min(this.heat + amount, this.heatCapacity);
   }
   /**
    * Remove heat from the reactor.

--- a/main.js
+++ b/main.js
@@ -172,8 +172,8 @@ toggleRunButton.addEventListener('click', () => {
 function gameTick() {
   // Run simulation
   grid.tick();
-  // Check for overheat; if heat exceeds capacity, remove all fuel cells and reset heat
-  if (state.heat > state.heatCapacity) {
+  // Check for overheat; if heat reaches capacity, remove all fuel cells and reset heat
+  if (state.heat >= state.heatCapacity) {
     alert('Reactor Meltdown! All fuel cells destroyed.');
     // Remove all fuel cells but leave other components
     for (let y = 0; y < grid.height; y++) {
@@ -184,6 +184,17 @@ function gameTick() {
         }
       }
     }
+    state.heat = 0;
+  }
+  // Check for power overload; if power reaches capacity, destroy all components
+  if (state.power >= state.powerCapacity) {
+    alert('Reactor Overload! All components destroyed.');
+    for (let y = 0; y < grid.height; y++) {
+      for (let x = 0; x < grid.width; x++) {
+        grid.removeComponent(x, y);
+      }
+    }
+    state.power = 0;
     state.heat = 0;
   }
   updateStats();


### PR DESCRIPTION
## Summary
- Cap reactor heat at its maximum capacity
- Trigger meltdown when heat or power reach their caps
- Destroy all components when power overloads
- Document capped resources and overload behaviour

## Testing
- `node --check main.js`
- `node --check components.js`


------
https://chatgpt.com/codex/tasks/task_e_6897a3cf19148330a62d90c852dd0348